### PR TITLE
Update Tests after Deprecation of Assumed Outputs

### DIFF
--- a/spec/bundler_spec.rb
+++ b/spec/bundler_spec.rb
@@ -4,7 +4,8 @@ describe "Bundler" do
     let(:gemfile_text) { File.read('Gemfile') }
     let(:bundle_output) do
       Bundler.with_unbundled_env do
-        `bundle`
+        # Use bundle list to show installed gems instead of reinstalling
+        `bundle list 2>&1`
       end
     end
 
@@ -49,7 +50,7 @@ describe "Bundler" do
 
         bundle_output_without_development = ""
         Bundler.with_unbundled_env do
-          bundle_output_without_development = `bundle config set --local without development`
+          bundle_output_without_development = `bundle config set --local without development && bundle list 2>&1`
         end
         expect(bundle_output_without_development =~ /pry/).to eq(nil)
       end
@@ -61,7 +62,7 @@ describe "Bundler" do
 
         bundle_output_without_test = ""
         Bundler.with_unbundled_env do
-          bundle_output_without_test = `bundle config set --local without test`
+          bundle_output_without_test = `bundle config set --local without test && bundle list 2>&1`
         end
         expect(bundle_output_without_test =~ /rspec/).to eq(nil)
       end
@@ -72,7 +73,7 @@ describe "Bundler" do
   describe "bundle install" do
     describe "Gemfile.lock" do
       it "exists after running `bundle install`" do
-        expect(File.exists?('Gemfile.lock')).to eq(true)
+        expect(File.exist?('Gemfile.lock')).to eq(true)
       end
     end
   end

--- a/spec/bundler_spec.rb
+++ b/spec/bundler_spec.rb
@@ -4,7 +4,7 @@ describe "Bundler" do
     let(:gemfile_text) { File.read('Gemfile') }
     let(:bundle_output) do
       Bundler.with_unbundled_env do
-        `bundle`
+        `bundle list 2>&1`
       end
     end
 
@@ -49,7 +49,7 @@ describe "Bundler" do
 
         bundle_output_without_development = ""
         Bundler.with_unbundled_env do
-          bundle_output_without_development = `bundle config set --local without development`
+          bundle_output_without_development = `bundle config set --local without development && bundle list 2>&1`
         end
         expect(bundle_output_without_development =~ /pry/).to eq(nil)
       end
@@ -61,7 +61,7 @@ describe "Bundler" do
 
         bundle_output_without_test = ""
         Bundler.with_unbundled_env do
-          bundle_output_without_test = `bundle config set --local without test`
+          bundle_output_without_test = `bundle config set --local without test && bundle list 2>&1`
         end
         expect(bundle_output_without_test =~ /rspec/).to eq(nil)
       end
@@ -72,7 +72,7 @@ describe "Bundler" do
   describe "bundle install" do
     describe "Gemfile.lock" do
       it "exists after running `bundle install`" do
-        expect(File.exists?('Gemfile.lock')).to eq(true)
+        expect(File.exist?('Gemfile.lock')).to eq(true)
       end
     end
   end


### PR DESCRIPTION
This pull request updates the `spec/bundler_spec.rb` file to improve the reliability and accuracy of test scenarios. Key changes include replacing `bundle` commands with `bundle list` for better output handling and correcting a method call for file existence checks.

### Improvements to test output handling:
* Updated the `bundle` command to `bundle list` in the `bundle_output` variable to show installed gems instead of reinstalling them. (`[spec/bundler_spec.rbL7-R8](diffhunk://#diff-b08e8915cad3c076e3f878367901ea3d863236bd276d0b720ffd4804d29f763aL7-R8)`)
* Modified commands in tests to append `bundle list` after setting `bundle config` options, ensuring the output reflects the current gem environment. (`[[1]](diffhunk://#diff-b08e8915cad3c076e3f878367901ea3d863236bd276d0b720ffd4804d29f763aL52-R53)`, `[[2]](diffhunk://#diff-b08e8915cad3c076e3f878367901ea3d863236bd276d0b720ffd4804d29f763aL64-R65)`)

### Code quality improvement:
* Replaced the deprecated `File.exists?` method with `File.exist?` for checking the existence of `Gemfile.lock` as it's been deprecated. (`[spec/bundler_spec.rbL75-R76](diffhunk://#diff-b08e8915cad3c076e3f878367901ea3d863236bd276d0b720ffd4804d29f763aL75-R76)`)